### PR TITLE
Docs deploy: copy hmi/README.md into the build context

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -3,6 +3,7 @@
 FROM node:22-alpine AS build
 WORKDIR /repo
 COPY docs ./docs
+COPY hmi/README.md ./hmi/README.md
 COPY website ./website
 WORKDIR /repo/website
 RUN npm ci && npm run build


### PR DESCRIPTION
The main-branch docs deploy failed after PR #2 merged: `sync-reference.mjs` now syncs `hmi/README.md` into the site, but the Dockerfile never copied it into the build context. Only the deploy job builds the container, and it only runs on main — so the PR's docs check couldn't catch it.

One-line fix, verified with a local `docker build -f website/Dockerfile .` which now completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHEnuBW99N7EcyVSBJggbr