### PR TITLE
CD scaffold: Dockerfile, redundant-pair k8s manifests, and a sha-rollout workflow

### DIFF
--- a/cmd/nautilus/new.go
+++ b/cmd/nautilus/new.go
@@ -43,6 +43,7 @@ type scaffold struct {
 	CI     bool // GitHub Actions workflow
 	VSCode bool // .vscode extension recommendation + runtime URL
 	Git    bool // git init
+	Deploy bool // Dockerfile + k8s manifests + CD workflow (manifest tier)
 
 	// Replace, if set, adds a filesystem `replace` directive pointing the
 	// nautilus dependency at a local checkout. For contributors testing
@@ -81,6 +82,11 @@ func (s *scaffold) settle() {
 	if s.Language == "" {
 		s.Language = "st"
 	}
+	// Deploy is a manifest-tier feature: the Dockerfile wraps the binary
+	// `nautilus build` emits, which the Go tier doesn't use.
+	if !s.NoGo() {
+		s.Deploy = false
+	}
 }
 
 var identRE = regexp.MustCompile(`[^A-Za-z0-9]+`)
@@ -98,6 +104,7 @@ func runNew(args []string) int {
 	// existing scripts don't break. Deliberately undocumented.
 	noGo := fs.Bool("no-go", false, "")
 	noInput := fs.Bool("no-input", false, "accept defaults instead of prompting")
+	deploy := fs.Bool("deploy", false, "add Dockerfile, k8s manifests, and a CD workflow (manifest templates)")
 	replace := fs.String("replace", "", "path to a local nautilus checkout; adds a filesystem replace directive so the project builds against it (for contributors, pre-publish)")
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -116,7 +123,7 @@ func runNew(args []string) int {
 	sc := scaffold{
 		Name:   name,
 		Module: *module,
-		CI:     true, VSCode: true, Git: true,
+		CI:     true, VSCode: true, Git: true, Deploy: *deploy,
 		Language: strings.ToLower(strings.TrimSpace(*language)),
 		Template: strings.ToLower(strings.TrimSpace(*tmpl)),
 	}
@@ -243,13 +250,18 @@ func prompt(sc *scaffold) error {
 		Value(&sc.Module)
 
 	features := []string{"ci", "vscode", "git"}
+	if sc.Deploy {
+		features = append(features, "deploy")
+	}
 	featureSelect := huh.NewMultiSelect[string]().
 		Title("Features").
+		Description("deploy applies to manifest templates (the Dockerfile wraps `nautilus build`)").
 		Description("Space to toggle, enter to confirm.").
 		Options(
 			huh.NewOption("GitHub Actions CI (check, test, build)", "ci").Selected(true),
 			huh.NewOption("VS Code setup (extension recommendation, live values)", "vscode").Selected(true),
 			huh.NewOption("git init", "git").Selected(true),
+			huh.NewOption("Kubernetes deploy (Dockerfile, manifests, CD workflow)", "deploy"),
 		).
 		Value(&features)
 
@@ -299,7 +311,7 @@ func prompt(sc *scaffold) error {
 		}
 		return false
 	}
-	sc.CI, sc.VSCode, sc.Git = has("ci"), has("vscode"), has("git")
+	sc.CI, sc.VSCode, sc.Git, sc.Deploy = has("ci"), has("vscode"), has("git"), has("deploy")
 	return nil
 }
 
@@ -340,6 +352,14 @@ func write(sc *scaffold) error {
 		{"program_blank.fbd.tmpl", "program.fbd", sc.Blank() && sc.Language == "fbd"},
 		{"program_blank.ld.tmpl", "program.ld", sc.Blank() && sc.Language == "ld"},
 		{"program_blank.sfc.tmpl", "program.sfc", sc.Blank() && sc.Language == "sfc"},
+
+		// Deploy scaffolding — commit-to-running-controller for the
+		// manifest tier: the Dockerfile wraps the binary `nautilus build`
+		// emits, the k8s manifests carry the RBAC the retain store and
+		// elector need, and the workflow pushes an image on every main.
+		{"Dockerfile.tmpl", "Dockerfile", sc.Deploy && sc.NoGo()},
+		{"deploy_k8s.yaml.tmpl", "deploy/k8s.yaml", sc.Deploy && sc.NoGo()},
+		{"deploy.yml.tmpl", ".github/workflows/deploy.yml", sc.Deploy && sc.NoGo()},
 
 		{"gitignore.tmpl", ".gitignore", true},
 		{"README.md.tmpl", "README.md", !sc.NoGo()},

--- a/cmd/nautilus/new_test.go
+++ b/cmd/nautilus/new_test.go
@@ -26,14 +26,17 @@ func TestScaffoldVariants(t *testing.T) {
 		absent []string
 	}{
 		{
+			// Deploy: true on a Go template proves the gate: the deploy
+			// scaffolding wraps `nautilus build`, which the SDK tier
+			// doesn't use, so asking for it must be a quiet no-op.
 			name: "sdk-demo with everything",
-			sc:   scaffold{Name: "plant-proj", Module: "example.com/plant-proj", Program: "PlantProj", Template: tmplSDKDemo, CI: true, VSCode: true},
+			sc:   scaffold{Name: "plant-proj", Module: "example.com/plant-proj", Program: "PlantProj", Template: tmplSDKDemo, CI: true, VSCode: true, Deploy: true},
 			want: []string{
 				"go.mod", "main.go", "plant.go", "program.st", "blocks.st", "program_test.go",
 				".github/workflows/ci.yml", ".vscode/extensions.json", ".vscode/settings.json",
 				"README.md", ".gitignore",
 			},
-			absent: []string{"driver.go", "nautilus.yaml"},
+			absent: []string{"driver.go", "nautilus.yaml", "Dockerfile", "deploy/k8s.yaml"},
 		},
 		{
 			name: "sdk, blank program",
@@ -64,7 +67,19 @@ func TestScaffoldVariants(t *testing.T) {
 				"nautilus.yaml", "program.fbd", "sim.st", "interlocks.ld", "blocks.st",
 				"demo-proj_test.yaml", "README.md", ".github/workflows/ci.yml",
 			},
-			absent: []string{"go.mod", "main.go", "plant.go", "program.st", "program_test.go"},
+			absent: []string{"go.mod", "main.go", "plant.go", "program.st", "program_test.go", "Dockerfile", "deploy/k8s.yaml"},
+		},
+		{
+			// Dockerfile and k8s manifests render template-clean; deploy.yml
+			// legitimately contains "{{" (GitHub's ${{ }} syntax), so it is
+			// asserted separately in TestDeployWorkflowRenders.
+			name: "demo with deploy",
+			sc:   scaffold{Name: "deploy-proj", Program: "DeployProj", Template: tmplDemo, CI: true, Deploy: true},
+			want: []string{
+				"nautilus.yaml", "Dockerfile", "deploy/k8s.yaml",
+				".github/workflows/ci.yml", "README.md",
+			},
+			absent: []string{"go.mod"},
 		},
 	}
 
@@ -140,6 +155,49 @@ func TestScaffoldVariants(t *testing.T) {
 	}
 }
 
+// deploy.yml renders GitHub's own ${{ }} expressions, which the generic
+// unrendered-"{{"-check would misread — so it gets its own assertions: Go
+// template actions are gone, the workflow's expressions and the project
+// name survived.
+func TestDeployWorkflowRenders(t *testing.T) {
+	dir := t.TempDir()
+	cwd, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(cwd)
+
+	sc := scaffold{Name: "wf-proj", Program: "WfProj", Template: tmplDemo, Deploy: true}
+	if err := write(&sc); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "wf-proj", ".github", "workflows", "deploy.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(raw)
+	for _, leftover := range []string{"{{.", "{{if", "{{end", `{{"`} {
+		if strings.Contains(s, leftover) {
+			t.Errorf("deploy.yml still contains template syntax %q", leftover)
+		}
+	}
+	for _, want := range []string{"nautilus build -o wf-proj", "${{ github.repository }}", "ghcr.io", "nautilus test ."} {
+		if !strings.Contains(s, want) {
+			t.Errorf("deploy.yml is missing %q", want)
+		}
+	}
+	// The manifest gained the sections the k8s Deployment depends on.
+	man, err := os.ReadFile(filepath.Join(dir, "wf-proj", "nautilus.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"retain: {}", "redundancy: {}"} {
+		if !strings.Contains(string(man), want) {
+			t.Errorf("nautilus.yaml is missing %q with deploy on", want)
+		}
+	}
+}
+
 func TestPascalCase(t *testing.T) {
 	for in, want := range map[string]string{
 		"water-plant": "WaterPlant",
@@ -158,11 +216,17 @@ func TestPascalCase(t *testing.T) {
 // the check that catches a broken template the moment it lands, rather
 // than in someone's first five minutes with the tool.
 func TestScaffoldedManifestProjectsPass(t *testing.T) {
-	for _, tc := range []struct{ name, template, language string }{
-		{"minimal-st", tmplMinimal, "st"},
-		{"minimal-fbd", tmplMinimal, "fbd"},
-		{"minimal-ld", tmplMinimal, "ld"},
-		{"demo", tmplDemo, ""},
+	for _, tc := range []struct {
+		name, template, language string
+		deploy                   bool
+	}{
+		{"minimal-st", tmplMinimal, "st", false},
+		{"minimal-fbd", tmplMinimal, "fbd", false},
+		{"minimal-ld", tmplMinimal, "ld", false},
+		{"demo", tmplDemo, "", false},
+		// deploy adds retain:/redundancy: to the manifest — the project
+		// must still load, compile, and pass its suites with them present.
+		{"demo-deploy", tmplDemo, "", true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
@@ -172,7 +236,7 @@ func TestScaffoldedManifestProjectsPass(t *testing.T) {
 			}
 			defer os.Chdir(cwd)
 
-			sc := scaffold{Name: tc.name, Program: pascalCase(tc.name), Template: tc.template, Language: tc.language}
+			sc := scaffold{Name: tc.name, Program: pascalCase(tc.name), Template: tc.template, Language: tc.language, Deploy: tc.deploy}
 			if err := write(&sc); err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/nautilus/templates/Dockerfile.tmpl
+++ b/cmd/nautilus/templates/Dockerfile.tmpl
@@ -1,0 +1,18 @@
+# The controller image. `nautilus build` already produced a self-contained
+# binary (runtime + this project, one file), so the image is just that file
+# on a distroless base — no toolchain here either. distroless/static rather
+# than scratch: MQTT/TLS needs CA roots, and debugging needs a real image
+# ancestry, but nothing needs a shell.
+#
+#   nautilus build -o {{.Name}}
+#   docker build -t {{.Name}} .
+#
+# The base has no libc, so the controller must be STATIC. The GitHub
+# Release binaries are; a CLI you `go install` yourself needs
+# CGO_ENABLED=0 (the scaffolded deploy.yml sets it).
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY {{.Name}} /controller
+# The tag API and dashboard; NAUTILUS_ADDR overrides.
+ENV NAUTILUS_ADDR=:8080
+EXPOSE 8080
+ENTRYPOINT ["/controller"]

--- a/cmd/nautilus/templates/README_nogo.md.tmpl
+++ b/cmd/nautilus/templates/README_nogo.md.tmpl
@@ -61,6 +61,23 @@ away from what the tests verify. Assertions are tag matchers
 Open the folder in VS Code with the **nautilus IEC 61131-3** extension for
 diagnostics, the graphical FBD/ladder editors, live tag values, and
 online edits against the running controller.
+{{if .Deploy}}
+## Deploy
+
+Every push to main that passes `check` + `test` becomes a controller
+image on GHCR (`.github/workflows/deploy.yml`). `deploy/k8s.yaml` runs it
+as a **redundant pair**: two replicas elect a scanning leader through a
+Lease, setpoints and online edits ride a ConfigMap across restarts and
+failovers, and the Service reaches live data on either replica.
+
+```sh
+kubectl apply -f deploy/k8s.yaml   # after pointing image: at your GHCR
+```
+
+Uncomment the rollout step in deploy.yml (and add a `KUBE_CONFIG`
+secret) to close the loop: a merged PR is running on the plant floor
+minutes later, by sha, with `kubectl rollout undo` as the way back.
+{{end}}
 
 When you need a custom field bus or richer simulation physics, that's the
 Go SDK: `nautilus new --template sdk` (or `sdk-demo`) scaffolds it, and

--- a/cmd/nautilus/templates/deploy.yml.tmpl
+++ b/cmd/nautilus/templates/deploy.yml.tmpl
@@ -1,0 +1,58 @@
+# Continuous deployment for control logic: every push to main that passes
+# check + test becomes a controller image on GHCR. The rollout step is the
+# one piece that needs your cluster — uncomment it once KUBE_CONFIG is set,
+# and a merged PR is running on the plant floor minutes later.
+name: deploy
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write # push the image to ghcr.io
+
+concurrency: deploy-main
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+      - name: install nautilus
+        # CGO_ENABLED=0 makes the CLI — and therefore the controller
+        # `nautilus build` emits from it — fully static, which the
+        # distroless/static base image requires. Release binaries are
+        # already built this way; `go install` is not, unless told.
+        run: CGO_ENABLED=0 go install github.com/joyautomation/nautilus/cmd/nautilus@latest
+      # The same gates as CI: nothing ships that does not check and pass
+      # its acceptance suites.
+      - run: nautilus check .
+      - run: nautilus test .
+      - name: build controller binary
+        run: nautilus build -o {{.Name}}
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{"{{"}} github.actor {{"}}"}}
+          password: ${{"{{"}} secrets.GITHUB_TOKEN {{"}}"}}
+      - name: build and push image
+        run: |
+          IMAGE=ghcr.io/${{"{{"}} github.repository {{"}}"}}
+          docker build -t "$IMAGE:${{"{{"}} github.sha {{"}}"}}" -t "$IMAGE:latest" .
+          docker push "$IMAGE:${{"{{"}} github.sha {{"}}"}}"
+          docker push "$IMAGE:latest"
+      # Rollout — uncomment once the repo has a KUBE_CONFIG secret (a
+      # kubeconfig scoped to this namespace). Rolling by sha, not latest,
+      # so every deploy is attributable to one commit and `rollout undo`
+      # means something.
+      # - name: roll out
+      #   env:
+      #     KUBECONFIG_DATA: ${{"{{"}} secrets.KUBE_CONFIG {{"}}"}}
+      #   run: |
+      #     echo "$KUBECONFIG_DATA" > kubeconfig
+      #     KUBECONFIG=kubeconfig kubectl set image deployment/{{.Name}} \
+      #       controller=ghcr.io/${{"{{"}} github.repository {{"}}"}}:${{"{{"}} github.sha {{"}}"}}
+      #     KUBECONFIG=kubeconfig kubectl rollout status deployment/{{.Name}} --timeout=120s

--- a/cmd/nautilus/templates/deploy_k8s.yaml.tmpl
+++ b/cmd/nautilus/templates/deploy_k8s.yaml.tmpl
@@ -1,0 +1,93 @@
+# {{.Name}} as a redundant pair: two replicas elect a scanning leader
+# through a Lease, retained state rides a ConfigMap, and the Service can
+# hit either replica — a standby proxies API traffic to the leader.
+# Enable the matching manifest sections (scaffolded in nautilus.yaml):
+#
+#   retain: {}
+#   redundancy: {}
+#
+# Point `image:` at where your CD pushes (deploy.yml pushes to GHCR).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{.Name}}
+---
+# Exactly the verbs the retain store and elector use — note no delete:
+# a releasing leader expires its own lease by writing an epoch renew
+# time, which is why failover on shutdown is immediate.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{.Name}}
+rules:
+  - apiGroups: [""]
+    resources: [configmaps]
+    verbs: [get, create, update]
+  - apiGroups: [coordination.k8s.io]
+    resources: [leases]
+    verbs: [get, create, update]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{.Name}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{.Name}}
+subjects:
+  - kind: ServiceAccount
+    name: {{.Name}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Name}}
+spec:
+  replicas: 2
+  selector:
+    matchLabels: {app: {{.Name}}}
+  template:
+    metadata:
+      labels: {app: {{.Name}}}
+    spec:
+      serviceAccountName: {{.Name}}
+      affinity:
+        podAntiAffinity:
+          # Prefer separate nodes, so one node loss keeps a replica.
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels: {app: {{.Name}}}
+      containers:
+        - name: controller
+          image: ghcr.io/YOUR_ORG/{{.Name}}:latest # deploy.yml pushes here
+          ports:
+            - {containerPort: 8080, name: api}
+          env:
+            # The elector's identity and the address standbys proxy to.
+            - name: POD_NAME
+              valueFrom: {fieldRef: {fieldPath: metadata.name}}
+            - name: POD_IP
+              valueFrom: {fieldRef: {fieldPath: status.podIP}}
+          readinessProbe:
+            # /api/cluster answers locally on every replica, leader or
+            # standby — a standby must stay Ready to serve the dashboard
+            # and proxy to the leader.
+            httpGet: {path: /api/cluster, port: api}
+            periodSeconds: 5
+          livenessProbe:
+            httpGet: {path: /api/cluster, port: api}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{.Name}}
+spec:
+  selector: {app: {{.Name}}}
+  ports:
+    - {port: 80, targetPort: api, name: http}

--- a/cmd/nautilus/templates/nautilus.yaml.tmpl
+++ b/cmd/nautilus/templates/nautilus.yaml.tmpl
@@ -7,6 +7,15 @@
 # `nautilus new --template sdk` scaffolds that form of this same project.
 name: {{.Name}}
 
+{{- if .Deploy}}
+
+# Deploy features (deploy/k8s.yaml runs two replicas of this controller):
+# setpoints and online edits survive restarts, and replicas elect one
+# scanning leader — see the Redundancy guide.
+retain: {}
+redundancy: {}
+{{- end}}
+
 server:
   addr: "localhost:8080"   # NAUTILUS_ADDR overrides; set NAUTILUS_TOKEN to gate writes
   online-edits: true       # PLC-style online edits from VS Code (off for production)

--- a/cmd/nautilus/templates/nautilus_demo.yaml.tmpl
+++ b/cmd/nautilus/templates/nautilus_demo.yaml.tmpl
@@ -11,6 +11,15 @@
 # `nautilus new --template sdk-demo`.
 name: {{.Name}}
 
+{{- if .Deploy}}
+
+# Deploy features (deploy/k8s.yaml runs two replicas of this controller):
+# setpoints and online edits survive restarts, and replicas elect one
+# scanning leader — see the Redundancy guide.
+retain: {}
+redundancy: {}
+{{- end}}
+
 server:
   addr: "localhost:8080"   # NAUTILUS_ADDR overrides; set NAUTILUS_TOKEN to gate writes
   online-edits: true       # PLC-style online edits from VS Code (off for production)

--- a/website/src/content/docs/guides/deployment.md
+++ b/website/src/content/docs/guides/deployment.md
@@ -1,0 +1,56 @@
+---
+title: Continuous deployment
+description: Commit-to-running-controller — every merge that passes its acceptance suites becomes a controller image, rolled out by sha to a redundant pair.
+---
+
+`nautilus new` with the **Kubernetes deploy** feature (or `--deploy`)
+scaffolds the whole pipeline:
+
+```
+Dockerfile                      the controller image (distroless, ~binary-sized)
+deploy/k8s.yaml                 redundant pair: RBAC, Deployment ×2, Service
+.github/workflows/deploy.yml    check → test → build → image → (rollout)
+```
+
+The chain is the pitch made concrete: a PR that fails its acceptance
+suites cannot merge (`ci.yml`); a merge that passes becomes an image
+tagged with its **sha**; the rollout step points the Deployment at that
+sha. Every controller running on the floor is attributable to one commit,
+and `kubectl rollout undo` is a one-command downgrade.
+
+## The image
+
+`nautilus build` already emits a self-contained controller — runtime plus
+project, one static binary — so the Dockerfile is three meaningful lines
+on `distroless/static`: no shell, no package manager, CA roots included
+for MQTT/TLS. The base has no libc, so the binary must be static: release
+CLIs are, and the workflow sets `CGO_ENABLED=0` for its own `go install`.
+
+## The cluster
+
+`deploy/k8s.yaml` runs **two replicas** with the manifest's `retain: {}`
+and `redundancy: {}` sections (scaffolded together): a Lease elects the
+scanning leader, setpoints and online edits ride a ConfigMap across
+restarts and failovers, and either replica answers the Service — a
+standby proxies API traffic to the leader. The RBAC is exactly the verbs
+those two objects need, delete not among them. See the
+[Redundancy guide](/guides/redundancy/) for how takeover works.
+
+Kill the leader and watch the tank not care:
+
+```sh
+kubectl delete pod -l app=<name> --field-selector ... # or just delete the leader
+# the standby's next 1s tick acquires the lease; worst case 4s
+```
+
+## The rollout
+
+The scaffolded workflow pushes to GHCR out of the box (nothing to
+configure — it uses the repo's own `GITHUB_TOKEN`). The final step —
+`kubectl set image` by sha + `rollout status` — ships commented, because
+it needs one secret only you can add: a namespace-scoped kubeconfig as
+`KUBE_CONFIG`. Uncomment it and the loop closes.
+
+Rolling by sha rather than `latest` is deliberate: a Deployment that says
+`:latest` redeploys to *whatever was pushed most recently*, which is a
+statement about time, not about code. A sha is a statement about code.


### PR DESCRIPTION
## Summary

The second half of the seams arc: `nautilus new --deploy` (or the "Kubernetes deploy" feature in the interactive scaffold) gives a manifest project the commit-to-running-controller pipeline:

- **Dockerfile** — `distroless/static` wrapping the self-contained binary from `nautilus build`; no toolchain, no shell, CA roots for MQTT/TLS. The static requirement is documented and enforced where we control the build (`CGO_ENABLED=0` in the workflow) — found the hard way when a locally built dynamic CLI produced a container that died with `exec /controller: no such file or directory`.
- **deploy/k8s.yaml** — a redundant pair: RBAC with exactly the verbs the retain store and elector use (no delete — release is expiry-by-write), Deployment ×2 with downward-API identity and probes that keep a standby Ready (it serves the dashboard and proxies to the leader), Service, soft anti-affinity.
- **deploy.yml** — check → test → `nautilus build` → image pushed to GHCR by sha and latest; the `kubectl set image` rollout ships commented, gated only on a `KUBE_CONFIG` secret. Rolling by sha so every running controller is attributable to one commit and `rollout undo` means something.
- Choosing deploy also scaffolds `retain: {}` + `redundancy: {}` into the manifest, so the pair actually elects and persists. The feature is manifest-tier only and quietly no-ops on Go templates (tested).
- New **Continuous deployment** guide on the site.

## Test plan

- [x] Scaffold variant tests incl. deploy-on-Go-template no-op; deploy.yml rendering asserted separately (it legitimately contains GitHub's `${{ }}`)
- [x] `demo-deploy` scaffolded project loads, compiles, and passes its acceptance suites with the new manifest sections present
- [x] End-to-end smoke: scaffold → `nautilus test` (4/4) → `nautilus build` → `docker build` → container runs, `/api/cluster` answers standalone/leader, tags live
- [x] Both scaffolded YAMLs parse; `go vet`, `nautilus check examples` green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHEnuBW99N7EcyVSBJggbr